### PR TITLE
Chop 43: Hook agents with plugins

### DIFF
--- a/core/domain/entity/plugin_result.go
+++ b/core/domain/entity/plugin_result.go
@@ -1,0 +1,8 @@
+package entity
+
+type PluginResultModel struct {
+	UUIDModel
+	Path       string
+	Output     string
+	OutputType string
+}

--- a/core/domain/orm.go
+++ b/core/domain/orm.go
@@ -36,6 +36,7 @@ func CreateDB(config *Cfg.Config) (*ORMConnection, error) {
 	checkMigrationError(db.AutoMigrate(&entity.TaskModel{}))
 	checkMigrationError(db.AutoMigrate(&entity.TaskResultModel{}))
 	checkMigrationError(db.AutoMigrate(&entity.AgentModel{}))
+	checkMigrationError(db.AutoMigrate(&entity.PluginResultModel{}))
 
 	fmt.Println("[+] Migrated Models.")
 

--- a/core/init.go
+++ b/core/init.go
@@ -10,11 +10,12 @@ func InitServices(db *orm.ORMConnection, frameworkConfig config.Config) services
 
 	userService := services.NewUserService(db)
 	return services.Services{
-		TeamService:   services.NewTeamService(db),
-		AgentService:  services.NewAgentService(db),
-		HostService:   services.NewHostService(db),
-		TaskService:   services.NewTaskService(db),
-		ReportService: services.NewReportService(db),
-		AuthService:   services.NewAuthService(userService, frameworkConfig),
+		TeamService:         services.NewTeamService(db),
+		AgentService:        services.NewAgentService(db),
+		HostService:         services.NewHostService(db),
+		TaskService:         services.NewTaskService(db),
+		ReportService:       services.NewReportService(db),
+		PluginResultService: services.NewPluginResultService(db),
+		AuthService:         services.NewAuthService(userService, frameworkConfig),
 	}
 }

--- a/core/plugins/plugin.go
+++ b/core/plugins/plugin.go
@@ -1,6 +1,10 @@
 // Package plugins defines how to load and interact with the framework plugins.
 package plugins
 
+import (
+	"github.com/chopper-c2-framework/c2-chopper/core/domain/entity"
+)
+
 // InfoRetriever:  it will only return its output.
 // SessionOpener in this case the framework has to prepare an agent and save the connection infos upons success.
 const (
@@ -40,6 +44,7 @@ type IPlugin interface {
 	MetaInfo() *Metadata
 	Info() *PluginInfo
 	Options() map[string]string
-	Exploit(...interface{}) []byte
+	Exploit(chan *entity.TaskResultModel, ...interface{}) []byte
 	SetArgs(...interface{}) error
+	IsWaitingForTaskResult() (bool, string)
 }

--- a/core/services/plugin_result.go
+++ b/core/services/plugin_result.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	"fmt"
+
+	orm "github.com/chopper-c2-framework/c2-chopper/core/domain"
+	"github.com/chopper-c2-framework/c2-chopper/core/domain/entity"
+	log "github.com/sirupsen/logrus"
+)
+
+type PluginResultService struct {
+	ORMConnection *orm.ORMConnection
+	repo          entity.TransactionRepository
+}
+
+func NewPluginResultService(db *orm.ORMConnection) PluginResultService {
+	logger := log.New()
+
+	repo := entity.NewGormRepository(db.Db, logger)
+	return PluginResultService{
+		repo: repo,
+	}
+}
+
+// CreateTeam Saving the new team to database
+func (t PluginResultService) CreatePluginResult(newRes *entity.PluginResultModel) error {
+	fmt.Println("[+] Creating plugin result", newRes)
+	err := t.repo.Create(newRes)
+
+	if err != nil {
+		log.Debugf("failed to create plugin result: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func (t PluginResultService) GetPluginResultsOrError(path string) ([]*entity.PluginResultModel, error) {
+	var results []*entity.PluginResultModel
+
+	err := t.repo.GetByField(&results, "path", path)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/core/services/types.go
+++ b/core/services/types.go
@@ -3,12 +3,18 @@ package services
 import "github.com/chopper-c2-framework/c2-chopper/core/domain/entity"
 
 type Services struct {
-	TeamService   ITeamService
-	AuthService   IAuthService
-	AgentService  IAgentService
-	HostService   IHostService
-	TaskService   ITaskService
-	ReportService IReportService
+	TeamService         ITeamService
+	AuthService         IAuthService
+	AgentService        IAgentService
+	HostService         IHostService
+	TaskService         ITaskService
+	ReportService       IReportService
+	PluginResultService IPluginResultService
+}
+
+type IPluginResultService interface {
+	CreatePluginResult(newRes *entity.PluginResultModel) error
+	GetPluginResultsOrError(path string) ([]*entity.PluginResultModel, error)
 }
 
 type ITeamService interface {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/gofiber/fiber/v2 v2.45.0
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
 	github.com/mattn/go-shellwords v1.0.12
@@ -22,7 +23,6 @@ require (
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/grpc/proto-files/plugin.proto
+++ b/grpc/proto-files/plugin.proto
@@ -11,6 +11,7 @@ service PluginService {
   rpc RunPlugin (RunPluginRequest) returns (RunPluginResponse) {}
   rpc LoadPlugin (LoadPluginRequest) returns (LoadPluginResponse) {}
   rpc GetPluginDetails (LoadPluginRequest) returns (LoadPluginResponse) {}
+  rpc GetPluginResults (GetPluginResultsRequest) returns (GetPluginResultsResponse) {}
 }
 
 message MapItem {
@@ -34,6 +35,14 @@ message ArgValue{
 message RunPluginRequest {
   string FileName = 1;
   map<string, ArgValue> Args = 2;
+}
+
+message GetPluginResultsRequest {
+  string file_name = 1;
+}
+
+message GetPluginResultsResponse {
+  repeated PluginResult results = 1;
 }
 
 message LoadPluginRequest {

--- a/grpc/proto-files/types.proto
+++ b/grpc/proto-files/types.proto
@@ -27,6 +27,14 @@ message Plugin {
   PluginInfo info = 3;
 }
 
+message PluginResult {
+  string id = 1;
+  string path = 2;
+  string output = 3;
+  string output_type = 4;
+  string created_at = 5;
+}
+
 message PluginMetadata {
   string version = 1;
   string author = 2;

--- a/server/cmd.go
+++ b/server/cmd.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/chopper-c2-framework/c2-chopper/core/config"
 	"github.com/urfave/cli/v2"
-
-	"github.com/chopper-c2-framework/c2-chopper/core/plugins"
 )
 
 // A channel to block the main thread. Well TODO: CHANGE IT IN A MORE PROPER WAY OF DOING THINGS
@@ -27,11 +25,10 @@ func GetCommands() []*cli.Command {
 				return nil
 			}
 
-			var pluginManager = plugins.CreatePluginManager(frameworkConfig)
 			var serverManager IServerManager = &Manager{}
 
 			go func() {
-				err := serverManager.NewgRPCServer(frameworkConfig, &pluginManager)
+				err := serverManager.NewgRPCServer(frameworkConfig)
 				if err != nil {
 					log.Println("Error launching GRPC server")
 					return

--- a/server/grpc/mappings.go
+++ b/server/grpc/mappings.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-
 )
 
 func ConvertTeamToProto(team *entity.TeamModel) *proto.Team {
@@ -65,6 +64,16 @@ func ConvertPluginToProto(plugin plugins.IPlugin) *proto.Plugin {
 		Description: pluginMeta.Description,
 	}
 	return &proto.Plugin{Info: info, Metadata: metadata}
+}
+
+func ConvertPluginResultToProto(res *entity.PluginResultModel) *proto.PluginResult {
+	return &proto.PluginResult{
+		Id:         res.ID.String(),
+		Path:       res.Path,
+		Output:     res.Output,
+		OutputType: res.OutputType,
+		CreatedAt:  res.CreatedAt.String(),
+	}
 }
 
 func ConvertTaskTypeToProto(task *entity.TaskModel) proto.TaskType {

--- a/server/grpc/plugin.go
+++ b/server/grpc/plugin.go
@@ -50,8 +50,6 @@ func (s *PluginService) RunPlugin(ctx context.Context, in *proto.RunPluginReques
 		args = append(args, GetValue(v))
 	}
 
-	loadedPlugin.Channel = make(chan *entity.TaskResultModel, 1)
-
 	// Set plugin arguments
 	err = plugin.SetArgs(args...)
 	if err != nil {
@@ -59,6 +57,7 @@ func (s *PluginService) RunPlugin(ctx context.Context, in *proto.RunPluginReques
 	}
 
 	// Start execution in a new thread. Store in db when result is ready.
+	loadedPlugin.Channel = make(chan *entity.TaskResultModel, 1)
 	go func() {
 		result := plugin.Exploit(loadedPlugin.Channel)
 		s.PluginResultService.CreatePluginResult(&entity.PluginResultModel{

--- a/server/grpc/plugin.go
+++ b/server/grpc/plugin.go
@@ -2,17 +2,21 @@ package grpc
 
 import (
 	context "context"
+	"errors"
 	"fmt"
 
 	"github.com/chopper-c2-framework/c2-chopper/grpc/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/chopper-c2-framework/c2-chopper/core/domain/entity"
 	"github.com/chopper-c2-framework/c2-chopper/core/plugins"
+	"github.com/chopper-c2-framework/c2-chopper/core/services"
 )
 
 type PluginService struct {
 	proto.UnimplementedPluginServiceServer
-	PluginManager plugins.IPluginManager
+	PluginManager       plugins.IPluginManager
+	PluginResultService services.IPluginResultService
 }
 
 func (s *PluginService) ListLoadedPlugins(ctx context.Context, in *emptypb.Empty) (*proto.ListLoadedPluginsResponse, error) {
@@ -32,41 +36,76 @@ func (s *PluginService) ListPlugins(ctx context.Context, in *emptypb.Empty) (*pr
 
 func (s *PluginService) RunPlugin(ctx context.Context, in *proto.RunPluginRequest) (*proto.RunPluginResponse, error) {
 	fmt.Println("[gRPC] [PluginService] RunPlugin")
-	plugin, err := s.PluginManager.GetPlugin(in.FileName)
+	loadedPlugin, err := s.PluginManager.GetPlugin(in.GetFileName())
 	if err != nil {
 		return &proto.RunPluginResponse{Success: false}, err
 	}
+	if loadedPlugin.Channel != nil {
+		return &proto.RunPluginResponse{}, errors.New("plugin is already executing.")
+	}
+	plugin := loadedPlugin.Plugin
 
 	var args []interface{}
 	for _, v := range in.Args {
 		args = append(args, GetValue(v))
 	}
 
-	// Run plugin & return result
+	loadedPlugin.Channel = make(chan *entity.TaskResultModel, 1)
+
+	// Set plugin arguments
 	err = plugin.SetArgs(args...)
 	if err != nil {
 		return &proto.RunPluginResponse{Success: false}, err
 	}
-	result := plugin.Exploit()
-	return &proto.RunPluginResponse{Success: true, Message: string(result)}, nil
+
+	// Start execution in a new thread. Store in db when result is ready.
+	go func() {
+		result := plugin.Exploit(loadedPlugin.Channel)
+		s.PluginResultService.CreatePluginResult(&entity.PluginResultModel{
+			Output:     string(result),
+			Path:       in.GetFileName(),
+			OutputType: "string",
+		})
+		loadedPlugin.Channel = nil
+	}()
+	return &proto.RunPluginResponse{Success: true, Message: "WIP"}, nil
 }
 
 func (s *PluginService) LoadPlugin(ctx context.Context, in *proto.LoadPluginRequest) (*proto.LoadPluginResponse, error) {
 	fmt.Println("[gRPC] [PluginService] LoadPlugin")
-	plugin, err := s.PluginManager.LoadPlugin(in.FileName)
+	loadedPlugin, err := s.PluginManager.LoadPlugin(in.FileName)
 	if err != nil {
 		return &proto.LoadPluginResponse{Success: false}, err
 	}
+	plugin := loadedPlugin.Plugin
+
 	return &proto.LoadPluginResponse{Success: true, Data: ConvertPluginToProto(plugin)}, nil
 }
 
 func (s *PluginService) GetPluginDetails(ctx context.Context, in *proto.LoadPluginRequest) (*proto.LoadPluginResponse, error) {
 	fmt.Println("[gRPC] [PluginService] GetPluginDetails")
-	plugin, err := s.PluginManager.GetPlugin(in.FileName)
+	loadedPlugin, err := s.PluginManager.GetPlugin(in.FileName)
 	if err != nil {
 		return &proto.LoadPluginResponse{Success: false}, err
 	}
+	plugin := loadedPlugin.Plugin
+
 	return &proto.LoadPluginResponse{Success: true, Data: ConvertPluginToProto(plugin)}, nil
+}
+
+func (s *PluginService) GetPluginResults(ctx context.Context, in *proto.GetPluginResultsRequest) (*proto.GetPluginResultsResponse, error) {
+	fmt.Println("[gRPC] [PluginService] GetPluginResults")
+	results, err := s.PluginResultService.GetPluginResultsOrError(in.GetFileName())
+	if err != nil {
+		return &proto.GetPluginResultsResponse{}, err
+	}
+
+	protoList := make([]*proto.PluginResult, len(results))
+	for i, res := range results {
+		protoList[i] = ConvertPluginResultToProto(res)
+	}
+
+	return &proto.GetPluginResultsResponse{Results: protoList}, nil
 }
 
 func GetValue(val *proto.ArgValue) interface{} {

--- a/server/internal/interceptor/auth.go
+++ b/server/internal/interceptor/auth.go
@@ -40,9 +40,10 @@ func (i *AuthInterceptor) IsAuthenticatedInterceptor(
 	if err != nil {
 		return nil, err
 	}
-
+	if user!=nil{
 	ctx = metadata.AppendToOutgoingContext(ctx, "userId", user.Id)
-
+	}
+	
 	return handler(ctx, req)
 }
 


### PR DESCRIPTION
* Added a new model to represent plugin results:

```go
type PluginResultModel struct {
    UUIDModel
    Path       string
    Output     string
    OutputType string
}
```

And added it's associated gRPC endpoints & db service:
```go
type IPluginResultService interface {
	CreatePluginResult(newRes *entity.PluginResultModel) error
	GetPluginResultsOrError(path string) ([]*entity.PluginResultModel, error)
}
```

* Changed `IPlugin` interface:
  1. `Exploit(chan *entity.TaskResultModel, ...interface{}) []byte`: Added channel for communication (Explained below)
  2. `IsWaitingForTaskResult() (bool, string)`: If waiting for a result of a task, returns (true, taskId). Else (false, "").
  3. `New(service services.ITaskService) plugins.IPlugin`: Pass TaskService to plugin constructor.

* Added a `LoadedPlugin` struct:
```go
type LoadedPluginInfo struct {
	Plugin  IPlugin
	Channel chan *entity.TaskResultModel
}
```
Channel will be used below for agent-plugin communication.

* Hook agents with plugins

Plugin behavior:
  - Pass agent id via arguments as a string. [PR#12](https://github.com/Chopper-C2-Framework/c2-chopper/pull/12) for reference.
  - In plugin, convert id to `UUID` & use it in TaskService to create a new task.
  - Wait for result in the channel passed to `Exploit` method. You'll get a `*TaskResult`

Plugin gRPC implementation:
  - In `RunPlugin` endpoint, create a new channel, set it associated to the targeted plugin.
  - Start the plugin execution in a new thread.
  - In the new thread code, when the plugin result is ready, store it in db & reset Channel.

Task gRPC implementation:
  - In `CreateTaskResult` endpoint, checks the loaded plugins if there is a plugin waiting for the new result.
  - If a plugin is found, the result is sent via the previously created channel.
